### PR TITLE
Changed volume declarations in Windows compose to use relative paths

### DIFF
--- a/docker-compose-win.yml
+++ b/docker-compose-win.yml
@@ -8,7 +8,7 @@ services:
       - 9115:9115
     volumes:
       - /etc/localtime:/etc/localtime:ro
-      - /var/lib/docker/volumes/pluralsightotel/blackbox/blackbox.yml:/etc/blackbox/blackbox.yml
+      - ./blackbox/blackbox.yml:/etc/blackbox/blackbox.yml
     command: --config.file=/etc/blackbox/blackbox.yml
     networks:
       otel:
@@ -23,8 +23,8 @@ services:
       - 9090:9090
     volumes:
       - /etc/localtime:/etc/localtime:ro
-      - /var/lib/docker/volumes/pluralsightotel/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
-      - /var/lib/docker/volumes/pluralsightotel/prometheus:/prometheus
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./prometheus:/prometheus
     depends_on:
       - blackbox
     networks:
@@ -37,8 +37,8 @@ services:
     command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
       - /etc/localtime:/etc/localtime:ro
-      - /var/lib/docker/volumes/pluralsightotel/tempo/tempo.yml:/etc/tempo.yaml
-      - /var/lib/docker/volumes/pluralsightotel/tempo:/tmp/tempo
+      - ./tempo/tempo.yml:/etc/tempo.yaml
+      - ./tempo:/tmp/tempo
     restart: unless-stopped
     ports:
       - 3200:3200  # tempo
@@ -55,8 +55,8 @@ services:
     command: -config.file=/etc/loki/local-config.yaml
     volumes:
       - /etc/localtime:/etc/localtime:ro      
-      - /var/lib/docker/volumes/pluralsightotel/loki/loki.yml:/etc/loki/local-config.yaml
-      - /var/lib/docker/volumes/pluralsightotel/loki:/data/loki
+      - ./loki/loki.yml:/etc/loki/local-config.yaml
+      - ./loki:/data/loki
     restart: unless-stopped
     ports:
       - 3100:3100
@@ -73,8 +73,9 @@ services:
       - GF_AUTH_DISABLE_LOGIN_FORM=true
     volumes:
       - /etc/localtime:/etc/localtime:ro
-      - /var/lib/docker/volumes/pluralsightotel/grafana/data:/var/lib/grafana
-      - /var/lib/docker/volumes/pluralsightotel/grafana/provisioning:/etc/grafana/provisioning
+      # Not sure what this should be because there is no such folder in the repo
+      #- grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning
     restart: unless-stopped
     user: root
     ports:
@@ -93,7 +94,7 @@ services:
     image: otel/opentelemetry-collector-contrib:0.75.0
     command: ["--config=/etc/otel-collector-config.yaml"]
     volumes:
-      - /var/lib/docker/volumes/pluralsightotel/otel/otel.yml:/etc/otel-collector-config.yaml
+      - ./otel/otel.yml:/etc/otel-collector-config.yaml
     restart: unless-stopped
     ports:
       - 8888:8888   # Prometheus metrics exposed by the collector


### PR DESCRIPTION
**What this PR does**
- Fixes the Windows compose yaml file to use relative paths for volume declarations. The existing version in `main` requires an exact path match to a particular dev machine.

**How to test this PR**
- Run `docker compose -f .\docker-compose-win.yml up -d` on a Windows machine.
  - The compose should succeed and all containers should start successfully.

**What this PR does not do**
- Set the grafana volume /var/lib/grafana, because I could not figure out what the source should have been. I left a comment in the yaml for this line.

**Docker Version Info**
```
Client:
 Cloud integration: v1.0.35-desktop+001
 Version:           24.0.5
 API version:       1.43
 Go version:        go1.20.6
 Git commit:        ced0996
 Built:             Fri Jul 21 20:36:24 2023
 OS/Arch:           windows/amd64
 Context:           default

Server: Docker Desktop 4.22.0 (117440)
 Engine:
  Version:          24.0.5
  API version:      1.43 (minimum version 1.12)
  Go version:       go1.20.6
  Git commit:       a61e2b4
  Built:            Fri Jul 21 20:35:45 2023
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.6.21
  GitCommit:        3dce8eb055cbb6872793272b4f20ed16117344f8
 runc:
  Version:          1.1.7
  GitCommit:        v1.1.7-0-g860f061
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```
**Docker Compose Version Info**
`Docker Compose version v2.20.2-desktop.1`